### PR TITLE
Fix buildSortQuery() bug, add some tests

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -226,24 +226,34 @@ trait SortableTrait
         return $this;
     }
 
-    public static function getSortableGroupField($model)
+    /*
+     * Determine the column name of the group column, null to disable grouping.
+     */
+    protected function determineGroupColumnName()
     {
-        return $model->sortable['sort_by_group_column'] ?? null;
+        if (
+            isset($this->sortable['sort_by_group_column']) &&
+            ! empty($this->sortable['sort_by_group_column'])
+        ) {
+            return $this->sortable['sort_by_group_column'];
+        }
+
+        return null;
     }
 
     /**
      * Build eloquent builder of sortable.
      *
+     * @param mixed $group
      */
     public function buildSortQuery()
     {
         $query = static::query();
 
-        $model       = new static;
-        $groupColumn = static::getSortableGroupField($model);
+        $groupColumn = $this->determineGroupColumnName();
 
         if ($groupColumn !== null) {
-            $query = $query->where($groupColumn, $model->$groupColumn);
+            $query = $query->where($groupColumn, $this->$groupColumn);
         }
 
         return $query;

--- a/tests/DummyWithGroups.php
+++ b/tests/DummyWithGroups.php
@@ -2,15 +2,15 @@
 
 namespace JMauerhan\EloquentSortable\Test;
 
+use JMauerhan\EloquentSortable\Test\Dummy;
+
 use JMauerhan\EloquentSortable\Sortable;
 use Illuminate\Database\Eloquent\Model;
 use JMauerhan\EloquentSortable\SortableTrait;
 
-class Dummy extends Model implements Sortable
+class DummyWithGroups extends Dummy
 {
-    use SortableTrait;
-
-    protected $table = 'dummies';
-    protected $guarded = [];
-    public $timestamps = false;
+    public $sortable = [
+        'sort_by_group_column' => 'group_column',
+    ];
 }

--- a/tests/DummyWithSoftDeletes.php
+++ b/tests/DummyWithSoftDeletes.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Spatie\EloquentSortable\Test;
+namespace JMauerhan\EloquentSortable\Test;
 
-use Spatie\EloquentSortable\Sortable;
+use JMauerhan\EloquentSortable\Sortable;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\EloquentSortable\SortableTrait;
+use JMauerhan\EloquentSortable\SortableTrait;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DummyWithSoftDeletes extends Model implements Sortable

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\EloquentSortable\Test;
+namespace JMauerhan\EloquentSortable\Test;
 
 use Illuminate\Support\Collection;
 
@@ -266,5 +266,63 @@ class SortableTest extends TestCase
                 $this->assertEquals($order, $newModels[$key]);
             }
         }
+    }
+
+    /** @test */
+    public function it_sets_the_order_column_on_creation_with_groups()
+    {
+        $this->setUpDummiesWithGroups();
+
+        foreach (DummyWithGroups::all() as $dummy) {
+            $this->assertEquals((int) (((int) $dummy->name + 2) / 3), $dummy->order_column);
+        }
+    }
+
+    /** @test */
+    public function it_only_moves_up_within_the_group()
+    {
+        $this->setUpDummiesWithGroups();
+
+        $firstModel = DummyWithGroups::find(3);
+        $secondModel = DummyWithGroups::find(6);
+        $otherGroupModel = DummyWithGroups::find(5);
+
+        $this->assertEquals($firstModel->order_column, 1);
+        $this->assertEquals($secondModel->order_column, 2);
+        $otherGroupModelOrder = $otherGroupModel->order_column;
+
+        $this->assertNotFalse($secondModel->moveOrderUp());
+
+        $firstModel = DummyWithGroups::find(3);
+        $secondModel = DummyWithGroups::find(6);
+        $otherGroupModel = DummyWithGroups::find(5);
+
+        $this->assertEquals($firstModel->order_column, 2);
+        $this->assertEquals($secondModel->order_column, 1);
+        $this->assertEquals($otherGroupModel->order_column, $otherGroupModelOrder);
+    }
+
+    /** @test */
+    public function it_only_moves_down_within_the_group()
+    {
+        $this->setUpDummiesWithGroups();
+
+        $firstModel = DummyWithGroups::find(3);
+        $secondModel = DummyWithGroups::find(6);
+        $otherGroupModel = DummyWithGroups::find(5);
+
+        $this->assertEquals($firstModel->order_column, 1);
+        $this->assertEquals($secondModel->order_column, 2);
+        $otherGroupModelOrder = $otherGroupModel->order_column;
+
+        $this->assertNotFalse($firstModel->moveOrderDown());
+
+        $firstModel = DummyWithGroups::find(3);
+        $secondModel = DummyWithGroups::find(6);
+        $otherGroupModel = DummyWithGroups::find(5);
+
+        $this->assertEquals($firstModel->order_column, 2);
+        $this->assertEquals($secondModel->order_column, 1);
+        $this->assertEquals($otherGroupModel->order_column, $otherGroupModelOrder);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\EloquentSortable\Test;
+namespace JMauerhan\EloquentSortable\Test;
 
 use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -56,6 +56,22 @@ abstract class TestCase extends Orchestra
     {
         $this->app['db']->connection()->getSchemaBuilder()->table('dummies', function (Blueprint $table) {
             $table->softDeletes();
+        });
+    }
+
+    protected function setUpDummiesWithGroups()
+    {
+        Dummy::truncate();
+
+        $this->app['db']->connection()->getSchemaBuilder()->table('dummies', function (Blueprint $table) {
+            $table->integer('group_column')->nullable();
+        });
+
+        collect(range(1, 20))->each(function (int $i) {
+            DummyWithGroups::create([
+                'name' => $i,
+                'group_column' => $i % 3,
+            ]);
         });
     }
 }


### PR DESCRIPTION
Hi, I noticed a small bug in buildSortQuery() which caused all newly created models to get the same initial order number. The function should work as intended now, and I also added some tests to verify the grouping functionality.